### PR TITLE
fix(py314-compatibility): replace ensure_future calls by create_task

### DIFF
--- a/mode/services.py
+++ b/mode/services.py
@@ -658,7 +658,7 @@ class Service(ServiceBase, ServiceCallbacks):
 
         The future will be joined when this service is stopped.
         """
-        fut = asyncio.ensure_future(self._execute_task(coro))
+        fut = self.loop.create_task(self._execute_task(coro))
         try:
             fut.set_name(repr(coro))
         except AttributeError:
@@ -1173,7 +1173,7 @@ class _AwaitableService(Service):
     async def on_start(self) -> None:
         # convert to future, so we can cancel on_stop
         try:
-            self._fut = asyncio.ensure_future(self.coro)
+            self._fut = self.loop.create_task(self.coro)
             await self._fut
         except asyncio.CancelledError:
             if not self.should_stop:

--- a/mode/services.py
+++ b/mode/services.py
@@ -658,7 +658,7 @@ class Service(ServiceBase, ServiceCallbacks):
 
         The future will be joined when this service is stopped.
         """
-        fut = asyncio.ensure_future(self._execute_task(coro), loop=self.loop)
+        fut = asyncio.ensure_future(self._execute_task(coro))
         try:
             fut.set_name(repr(coro))
         except AttributeError:
@@ -744,7 +744,7 @@ class Service(ServiceBase, ServiceCallbacks):
         coro = asyncio.wait(
             [
                 asyncio.ensure_future(
-                    c.wait() if isinstance(c, Event) else c, loop=self.loop
+                    c.wait() if isinstance(c, Event) else c
                 )
                 for c in coros
             ],
@@ -759,16 +759,15 @@ class Service(ServiceBase, ServiceCallbacks):
         timeout = want_seconds(timeout) if timeout is not None else None
         stopped = self._stopped
         crashed = self._crashed
-        loop = self.loop
 
         futures = {
             coro: asyncio.ensure_future(
-                coro if isinstance(coro, Awaitable) else coro.wait(), loop=loop
+                coro if isinstance(coro, Awaitable) else coro.wait()
             )
             for coro in coros
         }
-        futures[stopped] = asyncio.ensure_future(stopped.wait(), loop=loop)
-        futures[crashed] = asyncio.ensure_future(crashed.wait(), loop=loop)
+        futures[stopped] = asyncio.ensure_future(stopped.wait())
+        futures[crashed] = asyncio.ensure_future(crashed.wait())
         done: set[asyncio.Future]
         _pending: set[asyncio.Future]
         try:
@@ -808,8 +807,8 @@ class Service(ServiceBase, ServiceCallbacks):
 
     async def _wait_stopped(self, timeout: Seconds = None) -> None:
         timeout = want_seconds(timeout) if timeout is not None else None
-        stopped = asyncio.ensure_future(self._stopped.wait(), loop=self.loop)
-        crashed = asyncio.ensure_future(self._crashed.wait(), loop=self.loop)
+        stopped = asyncio.ensure_future(self._stopped.wait())
+        crashed = asyncio.ensure_future(self._crashed.wait())
         done, pending = await asyncio.wait(
             [stopped, crashed],
             return_when=asyncio.FIRST_COMPLETED,
@@ -1174,7 +1173,7 @@ class _AwaitableService(Service):
     async def on_start(self) -> None:
         # convert to future, so we can cancel on_stop
         try:
-            self._fut = asyncio.ensure_future(self.coro, loop=self.loop)
+            self._fut = asyncio.ensure_future(self.coro)
             await self._fut
         except asyncio.CancelledError:
             if not self.should_stop:

--- a/mode/services.py
+++ b/mode/services.py
@@ -743,9 +743,7 @@ class Service(ServiceBase, ServiceCallbacks):
         timeout = want_seconds(timeout) if timeout is not None else None
         coro = asyncio.wait(
             [
-                asyncio.ensure_future(
-                    c.wait() if isinstance(c, Event) else c
-                )
+                asyncio.ensure_future(c.wait() if isinstance(c, Event) else c)
                 for c in coros
             ],
             return_when=asyncio.ALL_COMPLETED,

--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -721,7 +721,7 @@ class flight_recorder(AbstractContextManager, LogSeverityMixin):
         if current_flight_recorder is not None:
             for k, v in current_flight_recorder.extra_context.items():
                 self.extra_context.setdefault(k, v)
-        self._fut = asyncio.ensure_future(self._waiting())
+        self._fut = self.loop.create_task(self._waiting())
 
     def cancel(self) -> None:
         fut, self._fut = self._fut, None

--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -721,7 +721,7 @@ class flight_recorder(AbstractContextManager, LogSeverityMixin):
         if current_flight_recorder is not None:
             for k, v in current_flight_recorder.extra_context.items():
                 self.extra_context.setdefault(k, v)
-        self._fut = asyncio.ensure_future(self._waiting(), loop=self.loop)
+        self._fut = asyncio.ensure_future(self._waiting())
 
     def cancel(self) -> None:
         fut, self._fut = self._fut, None

--- a/mode/worker.py
+++ b/mode/worker.py
@@ -245,7 +245,7 @@ class Worker(Service):
     def _schedule_shutdown(self, signal: signal.Signals) -> None:
         if not self._signal_stop_time:
             self._signal_stop_time = self.loop.time()
-            self._signal_stop_future = asyncio.ensure_future(
+            self._signal_stop_future = self.loop.create_task(
                 self._stop_on_signal(signal)
             )
 
@@ -258,7 +258,7 @@ class Worker(Service):
         self._starting_fut = None
         with exiting(file=self.stderr):
             try:
-                self._starting_fut = asyncio.ensure_future(
+                self._starting_fut = self.loop.create_task(
                     self.start()
                 )
                 self.loop.run_until_complete(self._starting_fut)
@@ -303,7 +303,7 @@ class Worker(Service):
             self.log.exception("Got exception while waiting: %r", exc)
         finally:
             # Then close the loop.
-            fut = asyncio.ensure_future(self._sentinel_task())
+            fut = self.loop.create_task(self._sentinel_task())
             self.loop.run_until_complete(fut)
             self.loop.stop()
             self.log.info("Closing event loop")

--- a/mode/worker.py
+++ b/mode/worker.py
@@ -246,7 +246,7 @@ class Worker(Service):
         if not self._signal_stop_time:
             self._signal_stop_time = self.loop.time()
             self._signal_stop_future = asyncio.ensure_future(
-                self._stop_on_signal(signal), loop=self.loop
+                self._stop_on_signal(signal)
             )
 
     async def _stop_on_signal(self, signal: signal.Signals) -> None:
@@ -259,7 +259,7 @@ class Worker(Service):
         with exiting(file=self.stderr):
             try:
                 self._starting_fut = asyncio.ensure_future(
-                    self.start(), loop=self.loop
+                    self.start()
                 )
                 self.loop.run_until_complete(self._starting_fut)
             except asyncio.CancelledError:
@@ -303,7 +303,7 @@ class Worker(Service):
             self.log.exception("Got exception while waiting: %r", exc)
         finally:
             # Then close the loop.
-            fut = asyncio.ensure_future(self._sentinel_task(), loop=self.loop)
+            fut = asyncio.ensure_future(self._sentinel_task())
             self.loop.run_until_complete(fut)
             self.loop.stop()
             self.log.info("Closing event loop")

--- a/mode/worker.py
+++ b/mode/worker.py
@@ -258,9 +258,7 @@ class Worker(Service):
         self._starting_fut = None
         with exiting(file=self.stderr):
             try:
-                self._starting_fut = self.loop.create_task(
-                    self.start()
-                )
+                self._starting_fut = self.loop.create_task(self.start())
                 self.loop.run_until_complete(self._starting_fut)
             except asyncio.CancelledError:
                 pass

--- a/tests/functional/test_service.py
+++ b/tests/functional/test_service.py
@@ -193,13 +193,13 @@ async def test_wait__future_cancelled():
         async def sleeper():
             await asyncio.sleep(10)
 
-        fut = asyncio.ensure_future(sleeper())
+        fut = asyncio.create_task(sleeper())
 
         async def canceller():
             await asyncio.sleep(0.1)
             fut.cancel()
 
-        fut2 = asyncio.ensure_future(canceller())
+        fut2 = asyncio.create_task(canceller())
         with pytest.raises(asyncio.CancelledError):
             await service.wait(fut)
 
@@ -213,13 +213,13 @@ async def test_wait__when_stopped():
         async def sleeper():
             await asyncio.sleep(10)
 
-        fut = asyncio.ensure_future(sleeper())
+        fut = asyncio.create_task(sleeper())
 
         async def stopper():
             await asyncio.sleep(0.1)
             await service.stop()
 
-        fut2 = asyncio.ensure_future(stopper())
+        fut2 = asyncio.create_task(stopper())
         assert (await service.wait(fut)).stopped
 
         fut2.cancel()
@@ -232,7 +232,7 @@ async def test_wait__when_crashed():
         async def sleeper():
             await asyncio.sleep(10)
 
-        fut = asyncio.ensure_future(sleeper())
+        fut = asyncio.create_task(sleeper())
 
         async def crasher():
             await asyncio.sleep(0.1)
@@ -241,7 +241,7 @@ async def test_wait__when_crashed():
             except RuntimeError as exc:
                 await service.crash(exc)
 
-        fut2 = asyncio.ensure_future(crasher())
+        fut2 = asyncio.create_task(crasher())
         assert await service.wait_for_stopped(fut)
 
         fut2.cancel()
@@ -261,9 +261,9 @@ async def test_wait__multiple_events():
             await asyncio.sleep(0.1)
             event2.set()
 
-        fut1 = asyncio.ensure_future(loser())
+        fut1 = asyncio.create_task(loser())
         try:
-            fut2 = asyncio.ensure_future(winner())
+            fut2 = asyncio.create_task(winner())
             try:
                 result = await service.wait_first(event1, event2)
                 assert not result.stopped

--- a/tests/functional/utils/test_queues.py
+++ b/tests/functional/utils/test_queues.py
@@ -33,7 +33,7 @@ class test_FlowControlQueue:
         flow_control.resume()
         await queue.put(1)
         flow_control.suspend()
-        asyncio.ensure_future(self._resume_soon(0.2, flow_control))  # noqa: RUF006
+        asyncio.create_task(self._resume_soon(0.2, flow_control))  # noqa: RUF006
         time_now = monotonic()
         await queue.put(2)
         assert monotonic() - time_now > 0.1
@@ -50,7 +50,7 @@ class test_FlowControlQueue:
         flow_control.resume()
         await queue.put(1)
         flow_control.suspend()
-        asyncio.ensure_future(self._resume_soon(0.2, flow_control))  # noqa: RUF006
+        asyncio.create_task(self._resume_soon(0.2, flow_control))  # noqa: RUF006
         time_now = monotonic()
         await queue.put(2)
         assert monotonic() - time_now > 0.1
@@ -60,7 +60,7 @@ class test_FlowControlQueue:
     async def test_suspend_resume__initially_suspended(self):
         flow_control = FlowControlEvent(initially_suspended=True)
         queue = FlowControlQueue(flow_control=flow_control)
-        asyncio.ensure_future(self._resume_soon(0.2, flow_control))  # noqa: RUF006
+        asyncio.create_task(self._resume_soon(0.2, flow_control))  # noqa: RUF006
         time_now = monotonic()
         await queue.put(1)
         assert await queue.get() == 1
@@ -131,7 +131,7 @@ class test_ThrowableQueue:
         async def clear_queue():
             queue.clear()
 
-        asyncio.ensure_future(clear_queue())  # noqa: RUF006
+        asyncio.create_task(clear_queue())  # noqa: RUF006
         with pytest.raises(asyncio.CancelledError):
             await queue.put(1)
 
@@ -150,7 +150,7 @@ class test_ThrowableQueue:
 
         queue._getters.append(done_future())
 
-        fut = asyncio.ensure_future(waiter())
+        fut = asyncio.create_task(waiter())
         await asyncio.sleep(0.01)
         await queue.throw(KeyError())
         await asyncio.gather(fut)

--- a/tests/functional/utils/test_tracebacks.py
+++ b/tests/functional/utils/test_tracebacks.py
@@ -17,7 +17,7 @@ async def test_format_task_stack():  # noqa: C901
         await baz()
 
     async def baz():
-        task = asyncio.ensure_future(xuz())
+        task = asyncio.create_task(xuz())
         await asyncio.sleep(0.1)
         for _ in range(100):
             assert format_task_stack(task, limit=0)
@@ -44,14 +44,14 @@ async def test_format_task_stack():  # noqa: C901
 
     await foo()
 
-    task = asyncio.ensure_future(xuz2())
+    task = asyncio.create_task(xuz2())
     await asyncio.sleep(0.05)
     assert format_task_stack(task, limit=None)
 
     async def moo():
         await asyncio.sleep(0.1)
 
-    task = asyncio.ensure_future(moo())
+    task = asyncio.create_task(moo())
     await asyncio.sleep(0.05)
     assert format_task_stack(task, limit=None)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -384,12 +384,8 @@ class test_Service:
 
             ensure_future.assert_has_calls(
                 [
-                    call(
-                        service._stopped.wait.return_value
-                    ),
-                    call(
-                        service._crashed.wait.return_value
-                    ),
+                    call(service._stopped.wait.return_value),
+                    call(service._crashed.wait.return_value),
                 ]
             )
 
@@ -597,9 +593,7 @@ class test_Service:
             res = await service.wait_many([m1, m2], timeout=3.34)
             assert res is service._wait_one.return_value
 
-            ensure_future.assert_has_calls(
-                [call(m1), call(m2)]
-            )
+            ensure_future.assert_has_calls([call(m1), call(m2)])
             wait.assert_called_once_with(
                 [ensure_future.return_value, ensure_future.return_value],
                 return_when=asyncio.ALL_COMPLETED,

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -385,10 +385,10 @@ class test_Service:
             ensure_future.assert_has_calls(
                 [
                     call(
-                        service._stopped.wait.return_value, loop=service.loop
+                        service._stopped.wait.return_value
                     ),
                     call(
-                        service._crashed.wait.return_value, loop=service.loop
+                        service._crashed.wait.return_value
                     ),
                 ]
             )
@@ -598,7 +598,7 @@ class test_Service:
             assert res is service._wait_one.return_value
 
             ensure_future.assert_has_calls(
-                [call(m1, loop=service.loop), call(m2, loop=service.loop)]
+                [call(m1), call(m2)]
             )
             wait.assert_called_once_with(
                 [ensure_future.return_value, ensure_future.return_value],

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -157,7 +157,7 @@ class test_Service:
 
         async def mywait():
             foo()
-            asyncio.ensure_future(s.stop())  # noqa: RUF006
+            asyncio.create_task(s.stop())  # noqa: RUF006
             await asyncio.sleep(10.0)
 
         s = service.from_awaitable(mywait())
@@ -650,7 +650,7 @@ class test_Service:
             # ``await`` any dangling ``async def`` calls
             # to avoid the "coroutine x was never awaited" warnings.
             for fut in to_cancel:
-                handle = asyncio.ensure_future(fut)
+                handle = asyncio.create_task(fut)
                 handle.cancel()
                 try:
                     await handle

--- a/tests/unit/test_threads.py
+++ b/tests/unit/test_threads.py
@@ -94,7 +94,7 @@ class test_ServiceThread:
         thread.add_future = AsyncMock(name="thread.add_future")
         thread._thread_running = None
         assert thread.parent_loop == event_loop
-        asyncio.ensure_future(self._wait_for_event(thread))  # noqa: RUF006
+        asyncio.create_task(self._wait_for_event(thread))  # noqa: RUF006
         await thread.start()
 
         thread.Worker.assert_called_once_with(thread)
@@ -108,7 +108,7 @@ class test_ServiceThread:
         thread.wait_for_thread = False
         thread._thread_running = None
         assert thread.parent_loop == event_loop
-        asyncio.ensure_future(self._wait_for_event(thread))  # noqa: RUF006
+        asyncio.create_task(self._wait_for_event(thread))  # noqa: RUF006
         await thread.start()
 
         thread.Worker.assert_called_once_with(thread)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -205,16 +205,13 @@ class test_Worker:
             cry.assert_called_once_with(file=worker.stderr)
 
     def test__schedule_shutdown(self, worker):
-        with patch("asyncio.ensure_future") as ensure_future:
-            worker._stop_on_signal = Mock()
-            worker._schedule_shutdown(Signals.SIGTERM)
-            assert worker._signal_stop_time
-            ensure_future.assert_called_once_with(
-                worker._stop_on_signal.return_value, loop=worker.loop
-            )
-            worker._stop_on_signal.assert_called_once_with(Signals.SIGTERM)
+        worker.loop = Mock()
+        worker._stop_on_signal = AsyncMock()
+        worker._schedule_shutdown(Signals.SIGTERM)
+        assert worker._signal_stop_time
+        worker._stop_on_signal.assert_called_once_with(Signals.SIGTERM)
 
-            worker._schedule_shutdown(Signals.SIGTERM)
+        worker._schedule_shutdown(Signals.SIGTERM)
 
     @pytest.mark.asyncio
     async def test__stop_on_signal(self, worker):
@@ -223,14 +220,11 @@ class test_Worker:
         worker.stop.assert_awaited_once()
 
     def test_execute_from_commandline(self, worker):
-        with self.patch_execute(worker) as ensure_future:
+        with self.patch_execute(worker):
             with pytest.raises(SystemExit) as excinfo:
                 worker.execute_from_commandline()
             assert excinfo.value.code == 0
-            assert worker._starting_fut is ensure_future.return_value
-            ensure_future.assert_called_once_with(
-                worker.start.return_value, loop=worker.loop
-            )
+            worker.start.assert_called_once()
             worker.stop_and_shutdown.assert_called_once_with()
 
     def test_execute_from_commandline__MemoryError(self, worker):
@@ -256,11 +250,9 @@ class test_Worker:
 
     @contextmanager
     def patch_execute(self, worker):
-        worker.loop = Mock()
-        worker.start = Mock()
+        worker.start = Mock(return_value=asyncio.sleep(0))
         worker.stop_and_shutdown = Mock()
-        with patch("asyncio.ensure_future") as ensure_future:
-            yield ensure_future
+        yield
 
     def test_on_worker_shutdown(self, worker):
         worker.on_worker_shutdown()
@@ -327,9 +319,8 @@ class test_Worker:
         worker._gather_all = Mock()
         worker.loop.is_running.return_value = is_running
         worker._sentinel_task = AsyncMock()
-        with patch("asyncio.ensure_future") as ensure_future:
-            with patch("asyncio.sleep", AsyncMock()):
-                yield ensure_future
+        with patch("asyncio.sleep", AsyncMock()):
+            yield
 
     @pytest.mark.asyncio
     async def test__sentinel_task(self, worker):

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -390,9 +390,7 @@ class test_flight_recorder:
                 bb.activate()
                 assert bb.started_at_date
                 assert bb.enabled_by is current_task.return_value
-                create_task.assert_called_once_with(
-                    bb._waiting.return_value
-                )
+                create_task.assert_called_once_with(bb._waiting.return_value)
                 assert bb._fut is create_task.return_value
 
     def test_activate__already_activated(self, bb):

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -386,14 +386,14 @@ class test_flight_recorder:
         bb._fut = None
         bb._waiting = Mock()
         with patch("mode.utils.logging.current_task") as current_task:
-            with patch("asyncio.ensure_future") as ensure_future:
+            with patch.object(bb.loop, "create_task") as create_task:
                 bb.activate()
                 assert bb.started_at_date
                 assert bb.enabled_by is current_task.return_value
-                ensure_future.assert_called_once_with(
+                create_task.assert_called_once_with(
                     bb._waiting.return_value
                 )
-                assert bb._fut is ensure_future.return_value
+                assert bb._fut is create_task.return_value
 
     def test_activate__already_activated(self, bb):
         bb._fut = Mock()

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -391,7 +391,7 @@ class test_flight_recorder:
                 assert bb.started_at_date
                 assert bb.enabled_by is current_task.return_value
                 ensure_future.assert_called_once_with(
-                    bb._waiting.return_value, loop=bb.loop
+                    bb._waiting.return_value
                 )
                 assert bb._fut is ensure_future.return_value
 


### PR DESCRIPTION
## Summary

Updates the codebase to support Python 3.14 by removing the deprecated `loop` parameter from asyncio functions and replacing `asyncio.ensure_future()` with `loop.create_task()` where appropriate. Maintains backward compatibility with Python 3.9+.

## Changes

### Production Code

- **mode/services.py**: 
  - `add_future()`, `_AwaitableService.on_start()`: Use `loop.create_task()` for spawning new tasks
  - `wait_many()`, `wait_first()`, `_wait_stopped()`: Keep `asyncio.ensure_future()` (without loop param) to handle both coroutines and existing Tasks/Futures

- **mode/worker.py**: 
  - `_schedule_shutdown()`, `execute_from_commandline()`, `_shutdown_loop()`: Use `loop.create_task()`

- **mode/utils/logging.py**: 
  - `flight_recorder.activate()`: Use `loop.create_task()`

Fixes https://github.com/numberly/mode/issues/4